### PR TITLE
25775 agent-jasmine-js improvements for multi threading launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,29 +47,108 @@ attachPicturesToLogs | It is 'true' or 'false', if set 'true' then attempts will
 
 ## Integrations
 ### Protractor integration
+### Launch agent in single thread mode.
+    If you launch protractor in single tread mode , just add agent initialization to the onPrepare function.
+    Add agent.getJasmineReporter to the  jasmine.getEnv().addReporter() as an argument. You can see this in the example bellow.
 Update your configuration file as follows:
 ```javascript
 var ReportportalAgent = require('agent-js-jasmine');
 
-var agent = new ReportportalAgent({
-    token: "00000000-0000-0000-0000-000000000000",
-    endpoint: "http://your-instance.com:8080/api/v1",
-    launch: "LAUNCH_NAME",
-    project: "PROJECT_NAME",
-    attachPicturesToLogs: false
-});
 ...
 exports.config = {
     ...
-    onPrepare() {
+    onPrepare: ()=> {
+    let agent = new ReportportalAgent({
+        token: "00000000-0000-0000-0000-000000000000",
+        endpoint: "http://your-instance.com:8080/api/v1",
+        launch: "LAUNCH_NAME",
+        project: "PROJECT_NAME",
+        attachPicturesToLogs: false
+    });
         ...
         jasmine.getEnv().addReporter(agent.getJasmineReporter());
     },
-    afterLaunch(number) {
+    afterLaunch:() => {
         return agent.getExitPromise();
     }
 };
 ```
+#### Settings for the multi threaded launch
+
+### Launch agents in multi thread mode.
+    For launching agents in multi thread mode firstly parent launch must be created and it ID
+ must be sent to the child launches , so they would send data to the right place, and wouldn't create new
+ launch instances at the Report Portal.
+    The main problem is that node.js is a single threaded platform. And for providing multi treading launch with browsers protractor generate
+ new processes  of node, which can't interact with each other, so Singelton objects or functions can't be created for synchronizing
+ it work. Only primitive types could be sent as args to the new processes before launch. The way of resolving this problem is
+ to create launch file that would generate a Parent Launch and send launch's ID to protractor as argument. Then protractor would
+ launch jasmine-agents with parent ID.
+ Look throug example of the Launch File with protractor-flake module at the 'Settings fot the multi threaded launch' section or at the examples folder.
+ Any node runner could be used!
+
+ Create a main launch file as in example below:
+
+launchFile.js
+
+```javascript
+'use strict';
+/* global process */
+const protractorFlake = require('protractor-flake');
+const AgentJasmine = require('agent-js-jasmine');
+const agent = new AgentJasmine({
+               token: "00000000-0000-0000-0000-000000000000",
+               endpoint: "http://your-instance.com:8080/api/v1",
+               launch: "LAUNCH_NAME",
+               project: "PROJECT_NAME",
+               attachPicturesToLogs: false,
+               tags: ["your", "tags"],
+               description: "DESCRIPTION"
+});
+    agent.startLaunch().then((realID) =>{
+            protractorFlake({
+                protractorArgs: [
+                    './protractorSpecFile.js',
+                    '--params.id',
+                    realID.id
+                ]
+            }, (status, output) => {
+                // Close the report after all tests finish
+               agent.getExitPromise().then(() =>{
+                   process.exit(status);
+               });
+
+             });
+    });
+```
+
+Then create protractor's spec file as in example below:
+
+protractorSpecFile.js file
+
+```javascript
+ onPrepare(){
+        agent = new AgentJasmine({
+            token: "00000000-0000-0000-0000-000000000000",
+            endpoint: "http://your-instance.com:8080/api/v1",
+            launch: "LAUNCH_NAME",
+            project: "PROJECT_NAME",
+            attachPicturesToLogs: false,
+            id : browser.params.id
+        });
+
+
+        /*Its a hack. There is an issue since 2015. That Jasmine doesn't wait for report's async functions.
+         So it needed to wait until requests would be sent to the Report Portal.
+         */
+        afterAll((done) => agent. getAllClientPromises(agent.tempLaunchId).then(()=> done()));
+
+        jasmine.getEnv().addReporter(agent.getJasmineReporter());
+    },
+```
+## Link to the jasmine issue , that it doesn't work well with async functions
+[jasmine issue](https://github.com/jasmine/jasmine/issues/842)
+[protractor's community](https://github.com/angular/protractor/issues/1938)
 
 # Copyright Notice
 Licensed under the [GPLv3](https://www.gnu.org/licenses/quick-guide-gplv3.html)

--- a/examples/protractor/multiThreadConf.js
+++ b/examples/protractor/multiThreadConf.js
@@ -1,0 +1,37 @@
+const ReportportalAgent = require('../../lib/reportportal-agent.js');
+
+
+exports.config = {
+    multiCapabilities: [
+        {
+            name: 'normal',
+            browserName: 'chrome',
+            maxInstances: 2,
+            shardTestFiles: true,
+            chromeOptions: {
+                args: ['--window-size=1024,768', '--disable-infobars']
+            }
+        }
+    ],
+    specs: ['testAngularPage.js', 'testGithubPage.js'],
+    onPrepare(){
+        agent = new ReportportalAgent({
+            token: "00000000-0000-0000-0000-000000000000",
+            endpoint: "http://your-instance.com:8080/api/v1",
+            launch: "LAUNCH_NAME",
+            project: "PROJECT_NAME",
+            attachPicturesToLogs: false,
+            id : browser.params.id
+        });
+
+        /*Its a hack. There is an issue since 2015. That Jasmine doesn't wait for report's async functions.
+         links to the issues https://github.com/jasmine/jasmine/issues/842
+         https://github.com/angular/protractor/issues/1938
+         So it needed to wait until requests would be sent to the Report Portal.
+         */
+        afterAll((done) => agent.getAllClientPromises(agent.tempLaunchId).then(()=> done()));
+
+        jasmine.getEnv().addReporter(agent.getJasmineReporter());
+    }
+
+};

--- a/examples/protractor/package.json
+++ b/examples/protractor/package.json
@@ -5,12 +5,14 @@
   "main": "index.js",
   "scripts": {
     "protractor": "protractor simpleConfig.js",
+    "protractor-mulr":"node protractorLaunchFile.js",
     "webdriver-update": "webdriver-manager update",
     "webdriver-start": "webdriver-manager start"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "protractor": "^5.1.2"
+    "protractor": "^5.1.2",
+    "protractor-flake": "^2.5.0"
   }
 }

--- a/examples/protractor/protractorLaunchFile.js
+++ b/examples/protractor/protractorLaunchFile.js
@@ -1,0 +1,27 @@
+'use strict';
+/* global process */
+/* Any type of launchers could be used, this is just for example as favorite one*/
+const protractorFlake = require('protractor-flake');
+const AgentJasmine = require('agent-js-jasmine');
+const agent = new ReportportalAgent({
+        token: "00000000-0000-0000-0000-000000000000",
+        endpoint: "http://your-instance.com:8080/api/v1",
+        launch: "LAUNCH_NAME",
+        project: "PROJECT_NAME",
+        attachPicturesToLogs: false
+    });
+
+agent.startLaunch().then((realID) =>{
+    protractorFlake({
+        protractorArgs: [
+            './multiThreadConf.js',
+            '--params.id',
+            realID.id
+        ]
+    }, (status, output) => {
+        // Close the report after all tests have finished
+        agent.getExitPromise().then(() =>{
+            process.exit(status);
+        });
+    });
+});

--- a/examples/protractor/simpleConfig.js
+++ b/examples/protractor/simpleConfig.js
@@ -1,16 +1,19 @@
-var ReportportalAgent = require('../../lib/reportportal-agent.js');
+const ReportportalAgent = require('../../lib/reportportal-agent.js');
+let agent;
 
-var agent = new ReportportalAgent({
-    token: "00000000-0000-0000-0000-000000000000",
-    endpoint: "http://your-instance.com:8080/api/v1",
-    launch: "LAUNCH_NAME",
-    project: "PROJECT_NAME",
-    attachPicturesToLogs: false
-});
 
 exports.config = {
+
     specs: ['testAngularPage.js', 'testGithubPage.js'],
     onPrepare(){
+            agent = new ReportportalAgent({
+            token: "00000000-0000-0000-0000-000000000000",
+            endpoint: "http://your-instance.com:8080/api/v1",
+            launch: "LAUNCH_NAME",
+            project: "PROJECT_NAME",
+            attachPicturesToLogs: false,
+        });
+
         jasmine.getEnv().addReporter(agent.getJasmineReporter());
     },
     afterLaunch(number) {

--- a/lib/reportportal-agent.js
+++ b/lib/reportportal-agent.js
@@ -9,18 +9,51 @@ class ReportportalAgent {
             project: '',
         }, conf);
         this.client = new ReportportalClient(config);
-        this.tempLaunchId = (this.client.startLaunch({})).tempId;
+        this.launchInstance = conf.id ? (this.client.startLaunch({id:conf.id})): (this.client.startLaunch({}));
+        this.tempLaunchId = this.launchInstance.tempId
         this.reporterConf = Object.assign({
             client: this.client,
             tempLaunchId: this.tempLaunchId,
             attachPicturesToLogs: true
         }, conf);
     }
+
     getJasmineReporter() {
         return new JasmineReportportalReporter(this.reporterConf);
     }
+
+    /*
+     * This method is used for launch finish when test run in one thread, and if test run in
+     * multi treading it must be call at the parent process ONLY, after all child processes have
+     * been finished
+     *
+     * @return a promise
+     */
     getExitPromise() {
         return (this.client.finishLaunch(this.tempLaunchId, {})).promise;
+    }
+
+    /*
+     * This method is used for creating a Parent Launch at the Report Portal in which child launches would
+     *  send their data
+     *  during the promise resolve id of the launch could be ejected and sent as @param
+     *  to the child launches.
+     *
+     *   @return a promise
+     */
+    startParentLaunch() {
+        return  this.launchInstance.promise
+    }
+
+    /*
+     * This method is used for frameworks as Jasmine and other. There is problems when
+     * it doesn't wait for promise resolve and stop the process. So it better to call
+     * this method at the spec's function as @afterAll() and manually resolve this promise.
+     *
+     * @return a promise
+     */
+    getAllClientPromises(launchTempId){
+        return this.client.getPromiseFinishAllItems(launchTempId)
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
     {
       "name": "Alexey Krylov",
       "email": "lexecon117@gmail.com"
+    },
+    {
+      "name": "Uladzimir Paliakou",
+      "email": "to.polyakov.vova@gmail.com"
     }
   ],
   "main": "./lib/reportportal-agent",
   "dependencies": {
-    "reportportal-client": "^5.0.0"
+    "reportportal-client": "^5.1.0"
   },
   "devDependencies": {
     "codecov": "^2.2.0",


### PR DESCRIPTION
## Description 
updates for the multithreading launching of the jasmine client.
There is a problem , that jasmine doesn't wait for async function. So it needed to use hacks for process stoping until request would be sent

## Issue
[issue](https://github.com/reportportal/agent-js-jasmine/issues/8) 

## Related PR
[Report portal client](https://github.com/reportportal/client-javascript/pull/14)

### Link to the jasmine issue , that it doesn't work well with async functions 
[jasmine issue](https://github.com/jasmine/jasmine/issues/842)
[protractor's community](https://github.com/angular/protractor/issues/1938)