### PR TITLE
fix: fix error `Value is not allowed for field 'status'` for excluded specs

### DIFF
--- a/lib/constants/testStatuses.js
+++ b/lib/constants/testStatuses.js
@@ -17,6 +17,7 @@
 const JasmineStatuses = {
     PENDING: 'pending',
     DISABLED: 'disabled',
+    EXCLUDED: 'excluded',
 };
 
 module.exports = { JasmineStatuses };

--- a/lib/jasmine-reportportal-reporter.js
+++ b/lib/jasmine-reportportal-reporter.js
@@ -314,7 +314,7 @@ class ReportportalReporter {
             attributes, description, testCaseId, logs = [], customStatus,
         } = this.additionalCustomParams;
         let status = customStatus || spec.status;
-        if (status === JasmineStatuses.PENDING || status === JasmineStatuses.DISABLED) {
+        if (Object.values(JasmineStatuses).includes(status)) {
             status = RP_STATUSES.SKIPPED;
         }
         let level = '';


### PR DESCRIPTION
Closes issue https://github.com/reportportal/agent-js-jasmine/issues/69